### PR TITLE
Add run_test.sh to run tests in build container

### DIFF
--- a/build_container/Dockerfile
+++ b/build_container/Dockerfile
@@ -21,4 +21,4 @@ RUN pip3 install grpcio grpcio-tools googleapis-common-protos
 # Dependencies for skinny server
 RUN go get -u github.com/gorilla/mux
 
-CMD ["/repo/build_container/build.sh"]
+CMD ["/repo/build_container/entry.sh"]

--- a/build_container/entry.sh
+++ b/build_container/entry.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -e
+
+export LOCAL_USER_ID
+export TEST_RABBLE
+
+/repo/build_container/build.sh
+
+if [ -n "${TEST_RABBLE}" ]
+then
+  /repo/build_container/test.sh
+fi

--- a/build_container/test.sh
+++ b/build_container/test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -e
+
+cd /repo
+
+cd chump/ && npm run lint && npm run test && cd ..
+
+# once we clean up the go build management, we should just be
+# able to run go test /go/src/github.com/cppsd/rabble/...
+# for all go dependencies
+
+go test skinny/*.go

--- a/chump/package.json
+++ b/chump/package.json
@@ -8,7 +8,8 @@
     "build:prod": "webpack --config webpack.config.js -d --mode production",
     "start": "webpack-dev-server --mode development --content-base ./dist --hot --inline --colors --port 3000 --open",
     "lint": "tslint --project .",
-    "clean": "rm -rf dist/*"
+    "clean": "rm -rf dist/*",
+    "test": "echo 'testing'"
   },
   "repository": {
     "type": "git",

--- a/run_build.sh
+++ b/run_build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
-
 set -e
+
+# run_build.sh builds all of docker's build using the build_container.
+# if _TEST_RABBLE is set, then it also runs the test script.
 
 USER_ID=`id -u $USER`
 
@@ -27,6 +29,7 @@ docker run \
   --rm \
   --volume $REPO_ROOT:/repo \
   -e LOCAL_USER_ID=$USER_ID \
+  -e TEST_RABBLE=$_TEST_RABBLE \
   rabble_build:latest
 
 echo "Done build"

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+set -e
+
+_TEST_RABBLE=ALL ./run_build.sh


### PR DESCRIPTION
Connects to #81 

- Adds an entry point for the docker container, which will always build.
  The test is run if an environment variable is set.
- Make the build script aware of the variable and add a run_test.sh to use it.

If we find the tests take a long time we might want to test only specific things, for now we just run every test.