### PR TITLE
use native context lib instead of x/net/context

### DIFF
--- a/services/example_go_python_microservice/go/gRPC_example.go
+++ b/services/example_go_python_microservice/go/gRPC_example.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 	protobuf "greetingCard"
 	"log"


### PR DESCRIPTION
The `context` package is part of the go stdlib as of 1.7, and using it from there is recommended. This shouldn't be an issue, as we shouldn't be using < 1.7; [grpc is dropping support for go <= 1.8 in a fortnight](https://github.com/grpc/grpc-go/issues/711#issuecomment-417123264).

I was using this file as a reference when I was doing #92; I think we should change this in case anyone else is going to look at this file as a reference in future and copy it.