### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+# Rabble CircleCI 2.0 configuration file
+
+version: 2
+jobs:
+  push_build_container:
+    docker:
+      # The language doesn't really matter, this is only used to make
+      # our container.
+      - image: circleci/python:3.6.4
+      
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: false  # Would be great, costs money.
+      - run: './run_build.sh --only-image'
+
+  run_tests:
+    docker:
+      - image: rabblenetwork/rabble_build:latest
+    environment:
+      LOCAL_USER: rabble
+      TEST_RABBLE: true
+    steps:
+      - checkout
+          path: /repo
+      - run: '/repo/build_container/entry.sh'
+
+workflows:
+  version: 2
+  create_image_and_test:
+    jobs:
+      - push_build_containier
+      - run_tests:
+          requires:
+            push_build_container
+


### PR DESCRIPTION
This pull request adds a config for CircleCI. Connects to #58 

There are two stages:
 - Creating a new build container and adding it to docker hub if it doesn't already exist
 - Actually running the tests inside the build container

There is one major tricky issue here: CircleCI will use whatever image was last pushed, I can't think of a way to guarantee the build container matches the Dockerfile in a given pull request. The exact edge case is:
 - Someone makes a change to the build container that breaks old builds
 - The container gets rebuilt and pushed to docker hub
 - A different PR with the old container is run in CI and is marked as broken because it has a container that's too new.

I can probably check for when that's happening and give a big warning but I don't think there's any way of getting around it really.