### PR TITLE
Add logger Python lib to database and follows service

### DIFF
--- a/build_container/build.sh
+++ b/build_container/build.sh
@@ -39,14 +39,6 @@ python3 -m grpc_tools.protoc \
   --grpc_python_out=build_out/database \
   build_out/database/database.proto
 
-echo "Building logger service"
-cp -R services/logger build_out/
-python3 -m grpc_tools.protoc \
-  -Ibuild_out/logger \
-  --python_out=build_out/logger \
-  --grpc_python_out=build_out/logger \
-  build_out/logger/logger.proto
-
 echo "Building follows service"
 cp -R services/follows build_out/
 python3 -m grpc_tools.protoc \
@@ -67,6 +59,19 @@ python3 -m grpc_tools.protoc \
   --python_out=build_out/article \
   --grpc_python_out=build_out/article \
   build_out/article/article.proto
+
+echo "Building logger service and lib"
+cp -R services/logger build_out/
+cp -R services/utils build_out/
+python3 -m grpc_tools.protoc \
+  -Ibuild_out/logger \
+  --python_out=build_out/utils \
+  --grpc_python_out=build_out/utils \
+  build_out/logger/logger.proto
+# Manually copy the needed files into the dirs, this is horrible.
+cp build_out/utils/* build_out/logger/
+cp build_out/utils/* build_out/follows/
+cp build_out/utils/* build_out/database/
 
 echo "Building protos for Go"
 # TODO(devoxel): fix this hell of manually building protos

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       dockerfile: Dockerfile
     volumes:
       - .:/repo
+    environment:
+      - LOGGER_SERVICE_HOST=logger_service
   follows_service:
     build:
       context: ./services/follows
@@ -27,6 +29,7 @@ services:
       - .:/repo
     environment:
       - DB_SERVICE_HOST=database_service
+      - LOGGER_SERVICE_HOST=logger_service
   logger_service:
     build:
       context: ./services/logger

--- a/services/database/main.py
+++ b/services/database/main.py
@@ -2,9 +2,9 @@
 from concurrent import futures
 import argparse
 import grpc
-import logging
 import time
 
+from logger import get_logger
 from database import build_database
 from database_servicer import DatabaseServicer
 import database_pb2_grpc
@@ -24,18 +24,9 @@ def get_args():
     return parser.parse_args()
 
 
-def get_logger(level):
-    # TODO(CianLR): Move to shared package and add ability to send to
-    # centralised logging service.
-    logger = logging.getLogger(__name__)
-    logger.addHandler(logging.StreamHandler())
-    logger.setLevel(level)
-    return logger
-
-
 def main():
     args = get_args()
-    logger = get_logger(args.v)
+    logger = get_logger("database_service", args.v)
     logger.info("Creating DB")
     database = build_database(logger, args.schema, args.db_path)
     logger.info("Creating server")

--- a/services/follows/main.py
+++ b/services/follows/main.py
@@ -2,11 +2,11 @@
 from concurrent import futures
 import argparse
 import grpc
-import logging
 import os
 import sys
 import time
 
+from logger import get_logger
 from servicer import FollowsServicer
 from util import Util
 
@@ -22,13 +22,6 @@ def get_args():
     return parser.parse_args()
 
 
-def get_logger(level):
-    logger = logging.getLogger(__name__)
-    logger.addHandler(logging.StreamHandler())
-    logger.setLevel(level)
-    return logger
-
-
 def get_database_service_address():
     host = os.environ['DB_SERVICE_HOST']
     if not host:
@@ -40,7 +33,7 @@ def get_database_service_address():
 
 def main():
     args = get_args()
-    logger = get_logger(args.v)
+    logger = get_logger('follows_service', args.v)
     logger.info('Creating server')
 
     util = Util(logger)

--- a/services/utils/logger.py
+++ b/services/utils/logger.py
@@ -1,0 +1,71 @@
+import os
+import grpc
+import logging
+import logger_pb2
+import logger_pb2_grpc
+from google.protobuf.timestamp_pb2 import Timestamp
+
+
+LOGGER_ENV_VAR = 'LOGGER_SERVICE_HOST'
+
+
+def get_logger(name, level):
+    logger = logging.getLogger(name)
+    # The logger should process everything.
+    logger.setLevel(logging.DEBUG)
+    # The stream out should be filtered.
+    sh = logging.StreamHandler()
+    sh.setLevel(level)
+    logger.addHandler(sh)
+    if LOGGER_ENV_VAR in os.environ:
+        logger_addr = os.environ[LOGGER_ENV_VAR] + ':1867'
+        logger.addHandler(GrpcHandler(name, logger_addr))
+    else:
+        logger.warning(LOGGER_ENV_VAR + ' env var not set, ' +
+                       'only logging locally')
+    return logger
+
+
+class LoggerConnectionException(Exception):
+    pass
+
+
+class GrpcHandler(logging.Handler):
+    def __init__(self, source_name, logger_addr, timeout=5):
+        super(GrpcHandler, self).__init__()
+        self.source_name = source_name
+        self.level_to_sev = {
+            'DEBUG': logger_pb2.Log.DEBUG,
+            'INFO': logger_pb2.Log.INFO,
+            'WARNING': logger_pb2.Log.WARNING,
+            'ERROR': logger_pb2.Log.ERROR,
+            'CRITICAL': logger_pb2.Log.CRITICAL,
+        }
+        self.channel = grpc.insecure_channel(logger_addr)
+        self.stub = logger_pb2_grpc.LoggerStub(self.channel)
+        chan_future = grpc.channel_ready_future(self.channel)
+        try:
+            chan_future.result(timeout=timeout)
+        except grpc.FutureTimeoutError:
+            raise LoggerConnectionException(
+                "Timed out after {} seconds connecting to {}"
+                    .format(timeout, logger_addr))
+    
+    def emit(self, record):
+        t = Timestamp()
+        t.seconds = int(record.created)
+        sev = self.level_to_sev[record.levelname]
+        log = logger_pb2.Log(
+            source=self.source_name,
+            severity=sev,
+            timestamp=t,
+            message=record.getMessage())
+        self.stub.WriteLog(log)
+
+    def close(self):
+        self.channel.close()
+        super(GrpcHandler, self).close()
+
+    
+
+


### PR DESCRIPTION
Connects to #38  

This adds a handler for the python logging library that sends logs over gRPC to the logger service.

Right now the build is super ugly, it's just copied into the dirs of the services that use it.
Definitely open to suggestions on that one.