### PR TITLE
Add creation_datetime to article entry into db

### DIFF
--- a/services/article/new_article_servicer.py
+++ b/services/article/new_article_servicer.py
@@ -13,6 +13,7 @@ class NewArticleServicer:
             author=req.author,
             title=req.title,
             body=req.body,
+            creation_datetime=req.creation_datetime,
             global_id= global_id
         )
         pr = database_pb2.PostsRequest(


### PR DESCRIPTION
Fix a bug which was caused by the article service dropping the creation_datetime