### PR TITLE
Change PYTHONPATH to allow normal importing from utils dir

### DIFF
--- a/build_container/build.sh
+++ b/build_container/build.sh
@@ -71,13 +71,15 @@ python3 -m grpc_tools.protoc \
   -Ibuild_out/logger \
   --python_out=build_out/utils \
   --grpc_python_out=build_out/utils \
+  --python_out=build_out/logger \
+  --grpc_python_out=build_out/logger \
+  --python_out=build_out/follows \
+  --grpc_python_out=build_out/follows \
+  --python_out=build_out/database \
+  --grpc_python_out=build_out/database \
+  --python_out=build_out/article \
+  --grpc_python_out=build_out/article \
   build_out/logger/proto/logger.proto
-
-# Manually copy the needed files into the dirs, this is horrible.
-cp -R build_out/utils/* build_out/logger/
-cp -R build_out/utils/* build_out/follows/
-cp -R build_out/utils/* build_out/database/
-cp -R build_out/utils/* build_out/article/
 
 echo "Building protos for Go"
 # This generate compiled protos and place them in the repo.

--- a/services/article/Dockerfile
+++ b/services/article/Dockerfile
@@ -6,6 +6,6 @@ RUN apk add --no-cache --update python3 python3-dev gcc g++ linux-headers make m
 RUN pip3 install grpcio
 RUN pip3 install protobuf
 
-ENV PYTHONPATH $PYTHONPATH:/repo/build_out/database
+ENV PYTHONPATH="/repo/build_out"
 
 CMD ["python3", "-u", "-B", "/repo/build_out/article/main.py", "-v"]

--- a/services/article/main.py
+++ b/services/article/main.py
@@ -6,7 +6,7 @@ import time
 import os
 import sys
 
-from logger import get_logger
+from utils.logger import get_logger
 from servicer import ArticleServicer
 from proto import article_pb2_grpc
 from proto import database_pb2_grpc

--- a/services/database/Dockerfile
+++ b/services/database/Dockerfile
@@ -6,6 +6,8 @@ RUN apk add --no-cache --update python3 python3-dev gcc g++ linux-headers make m
 RUN pip3 install grpcio
 RUN pip3 install protobuf
 
+ENV PYTHONPATH="/repo/build_out"
+
 CMD ["python3", "-u", "-B", "/repo/build_out/database/main.py", \
      "-v", "--schema", "/repo/build_out/database/rabble_schema.sql", \
      "--db_path", "/repo/rabble.db"]

--- a/services/database/main.py
+++ b/services/database/main.py
@@ -4,7 +4,7 @@ import argparse
 import grpc
 import time
 
-from logger import get_logger
+from utils.logger import get_logger
 from database import build_database
 from database_servicer import DatabaseServicer
 from proto import database_pb2_grpc

--- a/services/follows/Dockerfile
+++ b/services/follows/Dockerfile
@@ -6,4 +6,6 @@ RUN apk add --no-cache --update python3 python3-dev gcc g++ linux-headers make m
 RUN pip3 install grpcio
 RUN pip3 install protobuf
 
+ENV PYTHONPATH="/repo/build_out"
+
 CMD ["python3", "-u", "-B", "/repo/build_out/follows/main.py", "-v"]

--- a/services/follows/main.py
+++ b/services/follows/main.py
@@ -6,7 +6,7 @@ import os
 import sys
 import time
 
-from logger import get_logger
+from utils.logger import get_logger
 from servicer import FollowsServicer
 from util import Util
 

--- a/services/logger/Dockerfile
+++ b/services/logger/Dockerfile
@@ -6,5 +6,7 @@ RUN apk add --no-cache --update python3 python3-dev gcc g++ linux-headers make m
 RUN pip3 install grpcio
 RUN pip3 install protobuf
 
+ENV PYTHONPATH="/repo/build_out"
+
 CMD ["python3", "-u", "-B", "/repo/build_out/logger/main.py", \
      "-v", "-f", "/repo/rabble.log"]


### PR DESCRIPTION
Connects to #146 

This will allow us to import with the build_out dir as the base, I've changed over the logger for the moment but will find and fix any other imports too (either in this PR or a followup).

Due to some weird shit the protobufs still have to be build into the root of all the scripts using them.