### PR TITLE
Fix local go tests

### DIFF
--- a/skinny/main.go
+++ b/skinny/main.go
@@ -14,14 +14,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
-	"github.com/gorilla/mux"
-	"google.golang.org/grpc"
-
 	articlepb "github.com/cpssd/rabble/services/article/proto"
 	dbpb "github.com/cpssd/rabble/services/database/proto"
 	feedpb "github.com/cpssd/rabble/services/feed/proto"
 	followspb "github.com/cpssd/rabble/services/follows/proto"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/gorilla/mux"
+	"google.golang.org/grpc"
 )
 
 const (
@@ -100,14 +99,23 @@ func (s *serverWrapper) handleNotImplemented() http.HandlerFunc {
 	}
 }
 
-func (s *serverWrapper) handleIndex() http.HandlerFunc {
+func (s *serverWrapper) getIndexFile() []byte {
+	// This flag is used in "go test", so we can use that to check if we're
+	// in a test.
+	if flag.Lookup("test.v") != nil {
+		return []byte("testing html")
+	}
+
 	indexPath := path.Join(staticAssets, "index.html")
 	b, err := ioutil.ReadFile(indexPath)
-	if err != nil && flag.Lookup("test.v") != nil {
-		b = []byte("testing html")
-	} else if err != nil {
+	if err != nil {
 		log.Fatalf("could not find index.html: %v", err)
 	}
+	return b
+}
+
+func (s *serverWrapper) handleIndex() http.HandlerFunc {
+	b := s.getIndexFile()
 	return func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write(b)
 		if err != nil {


### PR DESCRIPTION
Doesn't really need an attached issue, just a small fix to main.go in skinny server that allows you to run the tests locally without the html dependency. 