### PR TITLE
Fix potential KeyErrors

### DIFF
--- a/services/activities/create/main.py
+++ b/services/activities/create/main.py
@@ -22,7 +22,7 @@ def get_args():
 
 
 def get_db_channel():
-    db_service_host = os.environ["DB_SERVICE_HOST"]
+    db_service_host = os.environ.get("DB_SERVICE_HOST")
     if not db_service_host:
         print("Please set DB_SERVICE_HOST env variable")
         sys.exit(1)

--- a/services/article/main.py
+++ b/services/article/main.py
@@ -24,7 +24,7 @@ def get_args():
 
 
 def get_db_channel(logger):
-    db_service_host = os.environ["DB_SERVICE_HOST"]
+    db_service_host = os.environ.get("DB_SERVICE_HOST")
     if not db_service_host:
         logger.error("Please set DB_SERVICE_HOST env variable")
         sys.exit(1)
@@ -33,7 +33,7 @@ def get_db_channel(logger):
 
 
 def get_create_channel(logger):
-    create_service_host = os.environ["CREATE_SERVICE_HOST"]
+    create_service_host = os.environ.get("CREATE_SERVICE_HOST")
     if not create_service_host:
         logger.error("Please set CREATE_SERVICE_HOST env variable")
         sys.exit(1)
@@ -42,7 +42,7 @@ def get_create_channel(logger):
 
 
 def get_mdc_channel(logger):
-    mdc_service_host = os.environ["MDC_SERVICE_HOST"]
+    mdc_service_host = os.environ.get("MDC_SERVICE_HOST")
     if not mdc_service_host:
         logger.error("Please set MDC_SERVICE_HOST env variable")
         sys.exit(1)

--- a/services/follows/main.py
+++ b/services/follows/main.py
@@ -24,7 +24,7 @@ def get_args():
 
 
 def get_database_service_address():
-    host = os.environ['DB_SERVICE_HOST']
+    host = os.environ.get('DB_SERVICE_HOST')
     if not host:
         logger.error('DB_SERVICE_HOST env var not set.')
         sys.exit(1)

--- a/services/utils/logger.py
+++ b/services/utils/logger.py
@@ -17,9 +17,9 @@ def get_logger(name, level):
     sh = logging.StreamHandler()
     sh.setLevel(level)
     logger.addHandler(sh)
-    if LOGGER_ENV_VAR in os.environ:
-        logger_addr = os.environ[LOGGER_ENV_VAR] + ':1867'
-        logger.addHandler(GrpcHandler(name, logger_addr))
+    logger_host = os.environ.get(LOGGER_ENV_VAR)
+    if logger_host:
+        logger.addHandler(GrpcHandler(name, logger_host + ':1867'))
     else:
         logger.warning(LOGGER_ENV_VAR + ' env var not set, ' +
                        'only logging locally')


### PR DESCRIPTION
`os.environ` is a dict, when we do a lookup without checking if they key exists it errors, not returns None.
This uses the `.get` method which does return None if the lookup doesn't exist