### PR TITLE
Fix typo in second server docker network

### DIFF
--- a/second-server.yml
+++ b/second-server.yml
@@ -107,7 +107,7 @@ services:
     volumes:
       - .:/repo
     networks:
-      - testnetwork
+      - rabble_testnetwork
       - default
     environment:
       - LOGGER_SERVICE_HOST=logger_service


### PR DESCRIPTION
network did not match network declared at top of file