### PR TITLE
Put recommender system training into try-catch

### DIFF
--- a/services/recommend_follows/get_servicer.py
+++ b/services/recommend_follows/get_servicer.py
@@ -79,11 +79,15 @@ class GetFollowRecommendationsServicer:
     def _compute_recommendations(self):
         self._logger.debug(
             'Recomputing recommendations. This may take some time.')
-        # It is necessary to reload data each time, as it may have changed.
-        self._data = self._convert_data(self._load_data())
-        self._algo = self._fit_model(self._data)
-        self._predictions = self._top_n(self._algo, self._data)
-        self._logger.debug('Finished computing recommendations.')
+        try:
+            # It is necessary to reload data each time, as it may have changed.
+            self._data = self._convert_data(self._load_data())
+            self._algo = self._fit_model(self._data)
+            self._predictions = self._top_n(self._algo, self._data)
+            self._logger.debug('Finished computing recommendations.')
+        except Exception as e:
+            self._logger.error('Could not compute recommendations:')
+            self._logger.error(str(e))
 
     def GetFollowRecommendations(self, request, context):
         self._logger.debug('GetFollowRecommendations, username = %s',


### PR DESCRIPTION
Forgot to add one change before merging before.

If the system has a small amount of data in it, it will fail, as the data won't be able to be split into a training and test set. This change stops this taking down the recommender system. 