### PR TITLE
Disallow duplicate registrations

### DIFF
--- a/services/database/rabble_schema.sql
+++ b/services/database/rabble_schema.sql
@@ -20,7 +20,8 @@ CREATE TABLE IF NOT EXISTS users (
   rss               text,
   /* account_type refers to the account_type enum in the database.proto file.
    * In normal cases, this will be 0, a normal user. */
-  private           boolean NOT NULL
+  private           boolean NOT NULL,
+  UNIQUE (handle, host)
 );
 
 /* follower and followed both match global_id in entries in users table. */


### PR DESCRIPTION
Closes #268 

Adds a UNIQUE constraint to the username/host pair in DB.
This still allows cian@skinny1 and cian@skinny2 to co-exist, it only fails if they're identical.

![unique](https://user-images.githubusercontent.com/11367575/51905603-8d6a8100-23b9-11e9-84e6-524e947416aa.png)
