### PR TITLE
Add error for blank user and password

### DIFF
--- a/services/users/test_login.py
+++ b/services/users/test_login.py
@@ -87,3 +87,15 @@ class LoginHandlerTest(unittest.TestCase):
         resp = self.login_handler.Login(req, None)
         self.assertEqual(resp.result, users_pb2.LoginResponse.DENIED)
 
+    def test_blank_password(self):
+        req = self._make_request()
+        req.password = ""
+        resp = self.login_handler.Login(req, None)
+        self.assertEqual(resp.result, users_pb2.LoginResponse.ERROR)
+
+    def test_blank_username(self):
+        req = self._make_request()
+        req.handle = ""
+        resp = self.login_handler.Login(req, None)
+        self.assertEqual(resp.result, users_pb2.LoginResponse.ERROR)
+

--- a/services/users/util.py
+++ b/services/users/util.py
@@ -25,6 +25,14 @@ def get_user_and_check_pw(logger, db_stub, handle, pw):
         if their password is incorrect: returns None, Error
         if their password is correct: returns UserEntry, None
     """
+    if not handle:
+        err = "Received blank username"
+        logger.warning(err)
+        raise ValueError(err)
+    if not pw:
+        err = "Received blank password"
+        logger.warning(err)
+        raise ValueError(err)
     find_request = database_pb2.UsersRequest(
         request_type=database_pb2.UsersRequest.FIND,
         match=database_pb2.UsersEntry(


### PR DESCRIPTION
Closes #265 

Added a check in the users service for a blank user and password. Added tests for both cases and also manually tested.