### PR TITLE
Add is_liked result to DB posts requests

### DIFF
--- a/services/database/posts_servicer.py
+++ b/services/database/posts_servicer.py
@@ -15,6 +15,16 @@ class PostsDatabaseServicer:
     def __init__(self, db, logger):
         self._db = db
         self._logger = logger
+        # If new columns are added to the database, this query must be
+        # changed. Change also _handle_insert.
+        self._select_base = (
+            "SELECT "
+            "p.global_id, p.author_id, p.title, p.body, "
+            "p.creation_datetime, p.md_body, p.ap_id, p.likes_count, "
+            "l.user_id IS NOT NULL "
+            "FROM posts p LEFT OUTER JOIN likes l ON "
+            "l.article_id=p.global_id AND l.user_id=? "
+        )
         self._type_handlers = {
             database_pb2.PostsRequest.INSERT: self._handle_insert,
             database_pb2.PostsRequest.FIND: self._handle_find,
@@ -32,22 +42,19 @@ class PostsDatabaseServicer:
         n = request.num_posts
         if not n:
             n = DEFAULT_NUM_POSTS
+        user_id = -1
+        if request.HasField("user_global_id"):
+            user_id = request.user_global_id.value
         self._logger.info('Reading {} posts for instance feed'.format(n))
         try:
             # TODO(iandioch): Fix user host insertion. Below query should have
             # 'WHERE users.host IS NULL' and not 'WHERE users.host = ""'.
-
-            # If new columns are added to the database, this query must be
-            # changed. Change also _handle_insert.
-            res = self._db.execute('SELECT posts.global_id, author_id, title, '
-                                   'body, creation_datetime, md_body, ap_id, '
-                                   'likes_count '
-                                   'FROM posts '
-                                   'INNER JOIN users '
-                                   'ON posts.author_id = users.global_id '
-                                   'WHERE users.host = "" AND users.private = 0 '
-                                   'ORDER BY posts.global_id DESC '
-                                   'LIMIT {} '.format(n))
+            res = self._db.execute(self._select_base +
+                                   'INNER JOIN users u '
+                                   'ON p.author_id = u.global_id '
+                                   'WHERE u.host = "" AND u.private = 0 '
+                                   'ORDER BY p.global_id DESC '
+                                   'LIMIT ?', user_id, n)
             for tup in res:
                 if not self._db_tuple_to_entry(tup, resp.results.add()):
                     del resp.results[-1]
@@ -60,7 +67,7 @@ class PostsDatabaseServicer:
     def _handle_insert(self, req, resp):
         try:
             # If new columns are added to the database, this query must be
-            # changed. Change also InstanceFeed.
+            # changed. Change also _select_base.
             self._db.execute(
                 'INSERT INTO posts '
                 '(author_id, title, body, creation_datetime, '
@@ -90,7 +97,7 @@ class PostsDatabaseServicer:
         resp.global_id = res[0][0]
 
     def _db_tuple_to_entry(self, tup, entry):
-        if len(tup) != 8:
+        if len(tup) != 9:
             self._logger.warning(
                 "Error converting tuple to PostsEntry: " +
                 "Wrong number of elements " + str(tup))
@@ -105,6 +112,7 @@ class PostsDatabaseServicer:
             entry.md_body = tup[5]
             entry.ap_id = tup[6]
             entry.likes_count = tup[7]
+            entry.is_liked = tup[8]
         except Exception as e:
             self._logger.warning(
                 "Error converting tuple to PostsEntry: " +
@@ -114,14 +122,18 @@ class PostsDatabaseServicer:
 
     def _handle_find(self, req, resp):
         filter_clause, values = util.equivalent_filter(req.match)
+        user_id = -1
+        if req.HasField("user_global_id"):
+            user_id = req.user_global_id.value
         try:
             if not filter_clause:
-                res = self._db.execute('SELECT * FROM posts')
+                res = self._db.execute(select_base, user_id)
             else:
                 res = self._db.execute(
-                    'SELECT * FROM posts WHERE ' + filter_clause +
-                    ' ORDER BY posts.global_id DESC ',
-                    *values)
+                    self._select_base +
+                    "WHERE " + filter_clause +
+                    " ORDER BY p.global_id DESC",
+                    *([user_id] + values))
         except sqlite3.Error as e:
             resp.result_type = database_pb2.PostsResponse.ERROR
             resp.error = str(e)

--- a/services/database/test_posts_servicer.py
+++ b/services/database/test_posts_servicer.py
@@ -4,6 +4,7 @@ import os
 
 import posts_servicer
 import users_servicer
+import like_servicer
 import database
 from services.proto import database_pb2
 
@@ -28,6 +29,7 @@ class PostsDatabaseHelper(unittest.TestCase):
         self.addCleanup(clean_database)
         self.posts = posts_servicer.PostsDatabaseServicer(self.db, logger)
         self.users = users_servicer.UsersDatabaseServicer(self.db, logger)
+        self.like = like_servicer.LikeDatabaseServicer(self.db, logger)
         self.ctx = fake_context()
 
     def add_post(self, author_id=None, title=None, body=None):
@@ -47,6 +49,15 @@ class PostsDatabaseHelper(unittest.TestCase):
                             database_pb2.PostsResponse.ERROR)
         return add_res
 
+    def add_like(self, liker_id, article_id):
+        req = database_pb2.LikeEntry(
+            user_id=liker_id,
+            article_id=article_id,
+        )
+        res = self.like.AddLike(req, self.ctx)
+        self.assertNotEqual(res.result_type, database_pb2.AddLikeResponse.ERROR)
+        return res
+
     def add_user(self, handle=None, host=None):
         user_entry = database_pb2.UsersEntry(
             handle=handle,
@@ -62,12 +73,23 @@ class PostsDatabaseHelper(unittest.TestCase):
                             database_pb2.UsersResponse.ERROR)
         return add_res
 
-    def instance_feed(self, n):
+    def instance_feed(self, n, user=None):
         req = database_pb2.InstanceFeedRequest(num_posts=n)
+        if user is not None:
+            req.user_global_id.value = user
         res = self.posts.InstanceFeed(req, self.ctx)
         self.assertNotEqual(res.result_type, database_pb2.PostsResponse.ERROR)
         return res
 
+    def find_post(self, author_id, user):
+        req = database_pb2.PostsRequest(
+            request_type=database_pb2.PostsRequest.FIND,
+            match=database_pb2.PostsEntry(author_id=author_id),
+        )
+        req.user_global_id.value = user
+        res = self.posts.Posts(req, self.ctx)
+        self.assertNotEqual(res.result_type, database_pb2.PostsResponse.ERROR)
+        return res
 
 class PostsDatabase(PostsDatabaseHelper):
 
@@ -108,6 +130,65 @@ class PostsDatabase(PostsDatabaseHelper):
             title='3 kissies',
             body='for the boys',
             creation_datetime={},
+        )
+        self.assertEqual(len(res.results), 2)
+        self.assertIn(want0, res.results)
+        self.assertIn(want1, res.results)
+
+    def test_instance_feed_is_liked(self):
+        self.add_user(handle='tayne', host=None)
+        self.add_user(handle='paul', host=None)
+        self.add_post(author_id=1, title='1 kissie', body='for the boys')
+        self.add_like(liker_id=2, article_id=1)
+        self.add_post(author_id=1, title='2 kissies', body='for the boys')
+
+        res = self.instance_feed(n=2, user=2)
+        want0 = database_pb2.PostsEntry(
+            global_id=1,
+            author_id=1,
+            title='1 kissie',
+            body='for the boys',
+            creation_datetime={},
+            likes_count=1,
+            is_liked=True,
+        )
+        want1 = database_pb2.PostsEntry(
+            global_id=2,
+            author_id=1,
+            title='2 kissies',
+            body='for the boys',
+            creation_datetime={},
+            is_liked=False,
+        )
+        self.assertEqual(len(res.results), 2)
+        self.assertIn(want0, res.results)
+        self.assertIn(want1, res.results)
+
+    def test_posts_is_liked(self):
+        self.add_user(handle='tayne', host=None)
+        self.add_user(handle='paul', host=None)
+        self.add_post(author_id=1, title='1 kissie', body='for the boys')
+        self.add_like(liker_id=2, article_id=1)
+        self.add_post(author_id=1, title='2 kissies', body='for the boys')
+        self.add_post(author_id=2, title='72 kissies', body='for the noah')
+
+        res = self.find_post(author_id=1, user=2)
+        want0 = database_pb2.PostsEntry(
+            global_id=1,
+            author_id=1,
+            title='1 kissie',
+            body='for the boys',
+            creation_datetime={},
+            likes_count=1,
+            is_liked=True,
+        )
+        want1 = database_pb2.PostsEntry(
+            global_id=2,
+            author_id=1,
+            title='2 kissies',
+            body='for the boys',
+            creation_datetime={},
+            is_liked=False,
         )
         self.assertEqual(len(res.results), 2)
         self.assertIn(want0, res.results)

--- a/services/proto/database.proto
+++ b/services/proto/database.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 option go_package = "services/proto";
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
 
 message PostsEntry {
   int64 global_id = 1;
@@ -14,6 +15,9 @@ message PostsEntry {
   string md_body = 6;
   string ap_id = 7;  // This is the URL ID, i.e. http://a.b/@cian/123
   int64 likes_count = 8;
+  // True if the user in the request has liked this post
+  // Note: defaults to false.
+  bool is_liked = 9;
 }
 
 message PostsRequest {
@@ -33,6 +37,9 @@ message PostsRequest {
 
   // Entry to INSERT or fields to UPDATE.
   PostsEntry entry = 3;
+
+  // The global ID of the user making this request, not set if none.
+  google.protobuf.UInt64Value user_global_id = 4;
 }
 
 message PostsResponse {
@@ -204,6 +211,8 @@ message LikesCollectionResponse {
 
 message InstanceFeedRequest {
   int32 num_posts = 1;
+  // The global ID of the user making this request, not set if none.
+  google.protobuf.UInt64Value user_global_id = 2;
 }
 
 message PendingFollowRequest {


### PR DESCRIPTION
Connects to #302 

Now you can specify a user context to the DB call and it will return if the user has liked a post or not.

I use one of Google's Wrapper classes when passing the user_global_id in the protobuf, this is because it's important to know if the field has been explicitly set or if it's just 0 by default, this is impossible for non-message fields. HACK.