### PR TITLE
Save logged in user to local storage

### DIFF
--- a/chump/src/index.tsx
+++ b/chump/src/index.tsx
@@ -27,7 +27,6 @@ interface IAppState {
 const LOCAL_STORAGE_USERNAME : string = "username";
 
 export class App extends React.Component<{}, IAppState> {
-
   constructor(props: {}) {
     super(props);
 


### PR DESCRIPTION
Closes #242

This saves the username to localstorage so when the app is loaded again it persists. 
Tested and seems to work totally fine.
 
![local_storage](https://user-images.githubusercontent.com/11367575/52346865-80343e80-2a18-11e9-8fee-b15e50d2fe16.png)
