### PR TITLE
Fix changing authors when mutiple hosts but same handle

### DIFF
--- a/services/activities/create/receive_create_servicer.py
+++ b/services/activities/create/receive_create_servicer.py
@@ -58,12 +58,13 @@ class ReceiveCreateServicer:
 
         return True
 
-    def _add_to_posts_db(self, author_handle, req):
+    def _add_to_posts_db(self, author_handle, author_id, req):
         self._logger.debug("Calling article service with new foreign article")
         # set flag in article service that is foreign (so no need to create service)
         # TODO(sailslick) Unstring foreign_id when pr #159 is merged
         na = article_pb2.NewArticle(
             author=author_handle,
+            author_id=author_id,
             title=req.title,
             body=req.content,
             creation_datetime=req.published,
@@ -98,7 +99,7 @@ class ReceiveCreateServicer:
             return resp
 
         # add to article db
-        added_flag = self._add_to_posts_db(author_handle, req)
+        added_flag = self._add_to_posts_db(author_handle, author_id, req)
         if added_flag == False:
             resp.result_type = create_pb2.CreateResponse.ERROR
             return resp

--- a/services/article/new_article_servicer.py
+++ b/services/article/new_article_servicer.py
@@ -37,14 +37,18 @@ class NewArticleServicer:
         return resp.result_type == search_pb2.IndexResponse.ResultType.Value("OK")
 
     def send_insert_request(self, req):
-        author = self._users_util.get_user_from_db(handle=req.author,
-                                                   host=None)
-        if author is None:
-            self._logger.error('Could not find user in db: ' + str(req.author))
-            return database_pb2.PostsResponse.error, None
+        global_id = req.author_id
+        if not req.foreign:
+            author = self._users_util.get_user_from_db(handle=req.author,
+                                                       host=None)
+            if author is None:
+                self._logger.error('Could not find user in db: ' + str(req.author))
+                return database_pb2.PostsResponse.error, None
+            global_id = author.global_id
+
         html_body = self.get_html_body(req.body)
         pe = database_pb2.PostsEntry(
-            author_id=author.global_id,
+            author_id=global_id,
             title=req.title,
             body=html_body,
             md_body=req.body,

--- a/services/proto/article.proto
+++ b/services/proto/article.proto
@@ -14,6 +14,7 @@ message NewArticle {
   bool foreign = 5;
   // The ActivityPub ID of this article. May not be set.
   string ap_id = 6;
+  int64 author_id = 7;
 }
 
 // NewArticleResponse is a simple response.


### PR DESCRIPTION
Fix a bug where the incorrect author would be chosen if there were multiple authors with the same handle but different hosts