### PR TITLE
Add skinny routes to get followers & following

### DIFF
--- a/skinny/handlers.go
+++ b/skinny/handlers.go
@@ -1021,3 +1021,37 @@ func (s *serverWrapper) handleGetFollowers() http.HandlerFunc {
 		}
 	}
 }
+
+func (s *serverWrapper) handleGetFollowing() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		v := mux.Vars(r)
+		username, ok := v["username"]
+		if !ok || username == "" {
+			w.WriteHeader(http.StatusBadRequest) // Bad Request.
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		fq := &pb.GetFollowsRequest{
+			Username: username,
+		}
+
+		followers, err := s.follows.GetFollowing(ctx, fq)
+		if err != nil {
+			log.Printf("Error in handleGetFollowers(): could not get followers: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		enc.SetEscapeHTML(false)
+		err = enc.Encode(followers)
+		if err != nil {
+			log.Printf("could not marshal followers: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+}

--- a/skinny/routes.go
+++ b/skinny/routes.go
@@ -36,6 +36,7 @@ func (s *serverWrapper) setupRoutes() {
 	r.HandleFunc("/c2s/@{username}/css", s.handleUserCss())
 	r.HandleFunc("/c2s/@{username}/recommend_follows", s.handleRecommendFollows())
 	r.HandleFunc("/c2s/@{username}/followers", s.handleGetFollowers())
+	r.HandleFunc("/c2s/@{username}/following", s.handleGetFollowing())
 	r.HandleFunc("/c2s/@{username}/{article_id}", s.handlePerArticlePage())
 	r.HandleFunc("/c2s/follow", s.handleFollow())
 	r.HandleFunc("/c2s/unfollow", s.handleUnfollow())


### PR DESCRIPTION
Connects to #464 
Connects to #466 

This is a small necessary PR that adds a skinny route that bridges the frontend and the follows service. 

The meat of the two issues is yet to come, but is essentially adding the UI and then making some attempt to handle getting the followers of foreign users (though I'm not sure about that yet).