### PR TITLE
Generate image hashes with SHA instead of MD5

### DIFF
--- a/run_build.sh
+++ b/run_build.sh
@@ -24,7 +24,7 @@ mkdir $BUILD_OUT
 
 
 DOCKERFILE="$REPO_ROOT/build_container/Dockerfile"
-DOCKERFILE_HASH="$(md5sum $DOCKERFILE | head -c 15)"
+DOCKERFILE_HASH="$(shasum $DOCKERFILE | head -c 40)"
 IMAGE="rabblenetwork/rabble_build"
 IMAGE_NAME="$IMAGE:$DOCKERFILE_HASH"
 


### PR DESCRIPTION
There was an issue with it not building on Mac OS (Mojave).
Will have to ask our friend Bianca to test.