### PR TITLE
Remove newlines in prints of client logs

### DIFF
--- a/services/database/log_servicer.py
+++ b/services/database/log_servicer.py
@@ -12,7 +12,7 @@ class LogDatabaseServicer:
     def AddLog(self, req, context):
         self._logger.debug(
             "Adding log '%s' by user %d",
-            req.message, req.user
+            req.message.strip(), req.user
         )
         response = db_pb.AddLogResponse()
         try:


### PR DESCRIPTION
Doesn't connect to any issue, but was annoying me.

If a client logs anything, right now it prints a double-newline to the console. It would be better just to print the log itself with just the one newline, like a normal log, because we're normal people.