### PR TITLE
Properly fetch actor documents when grabbing profile pictures

### DIFF
--- a/services/utils/users.py
+++ b/services/utils/users.py
@@ -46,8 +46,7 @@ class UsersUtil:
         """
         If a user being added is from a foreign host then get their actor
         and from that download their profile picture to the static assets
-        directory. This should all really be a webfinger thing but we don't
-        have that option at the time of writing.
+        directory.
         """
         try:
             actor_url = self._activ_util.build_actor(handle, host)


### PR DESCRIPTION
This code is a bit less disgusting now, so I took away @CianLR's TODO. The code is still a little awkward, and notably, **Mastodon can't figure out Rabble profile pictures**. This may be to do with MIMEs/missing file extensions?

However, the inverse is fine. Rabble can now display Mastodon profile pictures fine, it looks like:

![rabble showing a mastodon profile picture](https://i.imgur.com/GanEeKM.png)