### PR TITLE
Fix bad printf in go

### DIFF
--- a/services/feed/main.go
+++ b/services/feed/main.go
@@ -133,7 +133,7 @@ func (s *server) GetUserFeed(ctx context.Context, r *pb.FeedRequest) (*pb.FeedRe
 // It takes an optional username argument, if it exists it sends the request to
 // GetUserFeed, otherwise it returns all articles on the instance.
 func (s *server) Get(ctx context.Context, r *pb.FeedRequest) (*pb.FeedResponse, error) {
-	log.Printf("UserId: %s\n", r.UserId)
+	log.Printf("UserId: %v.\n", r.UserId)
 	if r.UserId != 0 {
 		return s.GetUserFeed(ctx, r)
 	}


### PR DESCRIPTION
I put a lot of work into this change, please don't go too hard on me in this code review.

Previously logged:
``2019/04/11 16:30:23 UserId: %!s(int64=0)``

Now logs:

`2019/04/11 16:51:00 UserId: 0.`