### PR TITLE
Fix updates triggering unique constraint

### DIFF
--- a/services/database/rabble_schema.sql
+++ b/services/database/rabble_schema.sql
@@ -46,7 +46,7 @@ CREATE TRIGGER IF NOT EXISTS UniqueUserHostInsertConstraint
 CREATE TRIGGER IF NOT EXISTS UniqueUserHostUpdateConstraint
   BEFORE UPDATE
   ON users
-  WHEN NEW.host IS NULL
+  WHEN NEW.host IS NULL AND NEW.handle != OLD.handle
   BEGIN
     SELECT CASE WHEN((
       SELECT 1


### PR DESCRIPTION
Updates were throwing the constraint because it was finding itself in the database